### PR TITLE
Adds putting proxy files in a proxy-specific folder. Closes #40

### DIFF
--- a/msgraph-developer-proxy/CertificateDiskCache.cs
+++ b/msgraph-developer-proxy/CertificateDiskCache.cs
@@ -1,0 +1,120 @@
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+using Titanium.Web.Proxy.Helpers;
+using Titanium.Web.Proxy.Network;
+
+namespace Microsoft.Graph.DeveloperProxy;
+
+// based on https://github.com/justcoding121/titanium-web-proxy/blob/9e71608d204e5b67085656dd6b355813929801e4/src/Titanium.Web.Proxy/Certificates/Cache/DefaultCertificateDiskCache.cs
+public sealed class CertificateDiskCache : ICertificateCache {
+    private const string DefaultCertificateDirectoryName = "crts";
+    private const string DefaultCertificateFileExtension = ".pfx";
+    private const string DefaultRootCertificateFileName = "rootCert" + DefaultCertificateFileExtension;
+    private string? rootCertificatePath;
+
+    public X509Certificate2? LoadRootCertificate(string pathOrName, string password, X509KeyStorageFlags storageFlags) {
+        var path = GetRootCertificatePath(pathOrName, false);
+        return LoadCertificate(path, password, storageFlags);
+    }
+
+    public void SaveRootCertificate(string pathOrName, string password, X509Certificate2 certificate) {
+        var path = GetRootCertificatePath(pathOrName, true);
+        var exported = certificate.Export(X509ContentType.Pkcs12, password);
+        File.WriteAllBytes(path, exported);
+    }
+
+    /// <inheritdoc />
+    public X509Certificate2? LoadCertificate(string subjectName, X509KeyStorageFlags storageFlags) {
+        var filePath = Path.Combine(GetCertificatePath(false), subjectName + DefaultCertificateFileExtension);
+        return LoadCertificate(filePath, string.Empty, storageFlags);
+    }
+
+    /// <inheritdoc />
+    public void SaveCertificate(string subjectName, X509Certificate2 certificate) {
+        var filePath = Path.Combine(GetCertificatePath(true), subjectName + DefaultCertificateFileExtension);
+        var exported = certificate.Export(X509ContentType.Pkcs12);
+        File.WriteAllBytes(filePath, exported);
+    }
+
+    public void Clear() {
+        try {
+            var path = GetCertificatePath(false);
+            if (Directory.Exists(path)) Directory.Delete(path, true);
+        }
+        catch (Exception) {
+            // do nothing
+        }
+    }
+
+    private X509Certificate2? LoadCertificate(string path, string password, X509KeyStorageFlags storageFlags) {
+        byte[] exported;
+
+        if (!File.Exists(path)) return null;
+
+        try {
+            exported = File.ReadAllBytes(path);
+        }
+        catch (IOException) {
+            // file or directory not found
+            return null;
+        }
+
+        return new X509Certificate2(exported, password, storageFlags);
+    }
+
+    private string GetRootCertificatePath(string pathOrName, bool create) {
+        if (Path.IsPathRooted(pathOrName)) return pathOrName;
+
+        return Path.Combine(GetRootCertificateDirectory(create),
+            string.IsNullOrEmpty(pathOrName) ? DefaultRootCertificateFileName : pathOrName);
+    }
+
+    private string GetCertificatePath(bool create) {
+        var path = GetRootCertificateDirectory(create);
+
+        var certPath = Path.Combine(path, DefaultCertificateDirectoryName);
+        if (create && !Directory.Exists(certPath)) Directory.CreateDirectory(certPath);
+
+        return certPath;
+    }
+
+    private string GetRootCertificateDirectory(bool create) {
+        if (rootCertificatePath == null) {
+            var proxyConfigurationFolderName = "msgraph-developer-proxy";
+
+            if (RunTime.IsUwpOnWindows) {
+                rootCertificatePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), proxyConfigurationFolderName);
+            }
+            else if (RunTime.IsLinux) {
+                rootCertificatePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), proxyConfigurationFolderName);
+            }
+            else if (RunTime.IsMac) {
+                rootCertificatePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), proxyConfigurationFolderName);
+            }
+            else {
+                var assemblyLocation = GetType().Assembly.Location;
+
+                // dynamically loaded assemblies returns string.Empty location
+                if (assemblyLocation == string.Empty) assemblyLocation = Assembly.GetEntryAssembly().Location;
+
+#if NETSTANDARD2_1
+                    // single-file app returns string.Empty location
+                    if (assemblyLocation == string.Empty)
+                    {
+                        assemblyLocation = AppContext.BaseDirectory;
+                    }
+#endif
+
+                var path = Path.GetDirectoryName(assemblyLocation);
+
+                rootCertificatePath = path ?? throw new NullReferenceException();
+            }
+        }
+
+        if (create && !Directory.Exists(rootCertificatePath)) {
+            Directory.CreateDirectory(rootCertificatePath);
+        }
+
+        return rootCertificatePath;
+    }
+}

--- a/msgraph-developer-proxy/CertificateDiskCache.cs
+++ b/msgraph-developer-proxy/CertificateDiskCache.cs
@@ -10,6 +10,8 @@ public sealed class CertificateDiskCache : ICertificateCache {
     private const string DefaultCertificateDirectoryName = "crts";
     private const string DefaultCertificateFileExtension = ".pfx";
     private const string DefaultRootCertificateFileName = "rootCert" + DefaultCertificateFileExtension;
+    private const string ProxyConfigurationFolderName = "msgraph-developer-proxy";
+
     private string? rootCertificatePath;
 
     public X509Certificate2? LoadRootCertificate(string pathOrName, string password, X509KeyStorageFlags storageFlags) {
@@ -80,22 +82,20 @@ public sealed class CertificateDiskCache : ICertificateCache {
 
     private string GetRootCertificateDirectory(bool create) {
         if (rootCertificatePath == null) {
-            var proxyConfigurationFolderName = "msgraph-developer-proxy";
-
             if (RunTime.IsUwpOnWindows) {
-                rootCertificatePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), proxyConfigurationFolderName);
+                rootCertificatePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), ProxyConfigurationFolderName);
             }
             else if (RunTime.IsLinux) {
-                rootCertificatePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), proxyConfigurationFolderName);
+                rootCertificatePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ProxyConfigurationFolderName);
             }
             else if (RunTime.IsMac) {
-                rootCertificatePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), proxyConfigurationFolderName);
+                rootCertificatePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), ProxyConfigurationFolderName);
             }
             else {
                 var assemblyLocation = GetType().Assembly.Location;
 
                 // dynamically loaded assemblies returns string.Empty location
-                if (assemblyLocation == string.Empty) assemblyLocation = Assembly.GetEntryAssembly().Location;
+                if (assemblyLocation == string.Empty) assemblyLocation = Assembly.GetEntryAssembly()?.Location;
 
 #if NETSTANDARD2_1
                     // single-file app returns string.Empty location

--- a/msgraph-developer-proxy/ChaosEngine.cs
+++ b/msgraph-developer-proxy/ChaosEngine.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Graph.DeveloperProxy {
             Console.WriteLine($"Configuring proxy for cloud {_config.Cloud} - {_config.HostName}");
             _proxyServer = new ProxyServer();
 
+            _proxyServer.CertificateManager.CertificateStorage = new CertificateDiskCache();
             _proxyServer.BeforeRequest += OnRequest;
             _proxyServer.BeforeResponse += OnResponse;
             _proxyServer.ServerCertificateValidationCallback += OnCertificateValidation;


### PR DESCRIPTION
Adds putting proxy files in a proxy-specific folder. Closes #40

Because the config path isn't exposed outside of the ProxyServer, implemented custom certificate cache handler where we can specify the config path including an app-specific folder.