### PR TITLE
Changes keyboard shortcut to stop to CTRL+C. Closes #47

### DIFF
--- a/msgraph-developer-proxy/ChaosEngine.cs
+++ b/msgraph-developer-proxy/ChaosEngine.cs
@@ -152,13 +152,18 @@ namespace Microsoft.Graph.DeveloperProxy {
         private void StopProxy() {
             // Unsubscribe & Quit
             try {
-                _explicitEndPoint.BeforeTunnelConnectRequest -= OnBeforeTunnelConnectRequest;
-                _proxyServer.BeforeRequest -= OnRequest;
-                _proxyServer.BeforeResponse -= OnResponse;
-                _proxyServer.ServerCertificateValidationCallback -= OnCertificateValidation;
-                _proxyServer.ClientCertificateSelectionCallback -= OnCertificateSelection;
+                if (_explicitEndPoint != null) {
+                    _explicitEndPoint.BeforeTunnelConnectRequest -= OnBeforeTunnelConnectRequest;
+                }
 
-                _proxyServer.Stop();
+                if (_proxyServer != null) {
+                    _proxyServer.BeforeRequest -= OnRequest;
+                    _proxyServer.BeforeResponse -= OnResponse;
+                    _proxyServer.ServerCertificateValidationCallback -= OnCertificateValidation;
+                    _proxyServer.ClientCertificateSelectionCallback -= OnCertificateSelection;
+
+                    _proxyServer.Stop();
+                }
             }
             catch (Exception ex) {
                 Console.WriteLine($"Exception: {ex.Message}");

--- a/msgraph-developer-proxy/ChaosEngine.cs
+++ b/msgraph-developer-proxy/ChaosEngine.cs
@@ -139,17 +139,30 @@ namespace Microsoft.Graph.DeveloperProxy {
             }
 
             // wait here (You can use something else as a wait function, I am using this as a demo)
-            Console.WriteLine("Press Enter to stop the Microsoft Graph Developer Proxy");
-            Console.ReadLine();
+            Console.WriteLine("Press CTRL+C to stop the Microsoft Graph Developer Proxy");
+            Console.CancelKeyPress += Console_CancelKeyPress;
+            // wait for the proxy to stop
+            while (_proxyServer.ProxyRunning) { Thread.Sleep(10); }
+        }
 
+        private void Console_CancelKeyPress(object? sender, ConsoleCancelEventArgs e) {
+            StopProxy();
+        }
+
+        private void StopProxy() {
             // Unsubscribe & Quit
-            _explicitEndPoint.BeforeTunnelConnectRequest -= OnBeforeTunnelConnectRequest;
-            _proxyServer.BeforeRequest -= OnRequest;
-            _proxyServer.BeforeResponse -= OnResponse;
-            _proxyServer.ServerCertificateValidationCallback -= OnCertificateValidation;
-            _proxyServer.ClientCertificateSelectionCallback -= OnCertificateSelection;
+            try {
+                _explicitEndPoint.BeforeTunnelConnectRequest -= OnBeforeTunnelConnectRequest;
+                _proxyServer.BeforeRequest -= OnRequest;
+                _proxyServer.BeforeResponse -= OnResponse;
+                _proxyServer.ServerCertificateValidationCallback -= OnCertificateValidation;
+                _proxyServer.ClientCertificateSelectionCallback -= OnCertificateSelection;
 
-            _proxyServer.Stop();
+                _proxyServer.Stop();
+            }
+            catch (Exception ex) {
+                Console.WriteLine($"Exception: {ex.Message}");
+            }
         }
 
         private void OnCancellation() {


### PR DESCRIPTION
Changes keyboard shortcut to stop to CTRL+C. Closes #47

The only caveat I noticed is that during debugging, when you press CTRL+C, the proxy unsubscribes and stops but the terminal window doesn't close and the process keeps running. You can stop the process from Visual Studio without any side-effects. When pressing CTRL+C during a normal execution in the terminal, the process stops as expected.