### PR TITLE
Update multi-URL spec to watch full URLs

### DIFF
--- a/specs/multi-url-support.md
+++ b/specs/multi-url-support.md
@@ -24,10 +24,8 @@ This configuration can also be extended by "any" URLs to support 1P endpoints, v
     "https://graph.microsoft.us/beta/*",
     "https://dod-graph.microsoft.us/v1.0/*",
     "https://dod-graph.microsoft.us/beta/*",
-
     "https://microsoftgraph.chinacloudapi.cn/v1.0/*",
     "https://microsoftgraph.chinacloudapi.cn/beta/*",
-
     "https://*.sharepoint.*/*_api/*",
     "https://*.sharepoint.*/*_vti_bin/*",
     "https://*.sharepoint-df.*/*_api/*",

--- a/specs/multi-url-support.md
+++ b/specs/multi-url-support.md
@@ -22,7 +22,9 @@ This configuration can also be extended by "any" URLs to support 1P endpoints, v
     "https://graph.microsoft.com/beta/*",
     "https://graph.microsoft.us/v1.0/*",
     "https://graph.microsoft.us/beta/*",
-    "https://dod-graph.microsoft.us/*",
+    "https://dod-graph.microsoft.us/v1.0/*",
+    "https://dod-graph.microsoft.us/beta/*",
+
     "https://microsoftgraph.chinacloudapi.cn/v1.0/*",
     "https://microsoftgraph.chinacloudapi.cn/beta/*",
 

--- a/specs/multi-url-support.md
+++ b/specs/multi-url-support.md
@@ -20,7 +20,8 @@ This configuration can also be extended by "any" URLs to support 1P endpoints, v
   "urlsToWatch": [
     "https://graph.microsoft.com/v1.0/*",
     "https://graph.microsoft.com/beta/*",
-    "https://graph.microsoft.us/*",
+    "https://graph.microsoft.us/v1.0/*",
+    "https://graph.microsoft.us/beta/*",
     "https://dod-graph.microsoft.us/*",
     "https://microsoftgraph.chinacloudapi.cn/*",
     "https://*.sharepoint.*/*_api/*",

--- a/specs/multi-url-support.md
+++ b/specs/multi-url-support.md
@@ -23,7 +23,9 @@ This configuration can also be extended by "any" URLs to support 1P endpoints, v
     "https://graph.microsoft.us/v1.0/*",
     "https://graph.microsoft.us/beta/*",
     "https://dod-graph.microsoft.us/*",
-    "https://microsoftgraph.chinacloudapi.cn/*",
+    "https://microsoftgraph.chinacloudapi.cn/v1.0/*",
+    "https://microsoftgraph.chinacloudapi.cn/beta/*",
+
     "https://*.sharepoint.*/*_api/*",
     "https://*.sharepoint.*/*_vti_bin/*",
     "https://*.sharepoint-df.*/*_api/*",

--- a/specs/multi-url-support.md
+++ b/specs/multi-url-support.md
@@ -6,8 +6,8 @@ Some applications are using an hybrid approach when it comes to consuming APIs. 
 
 | Version | Date | Comments | Author |
 | ------- | -------- | ----- | --- |
+| 1.1 | 2022-12-16 | change hosts to full URLs | @waldekmastykarz |
 | 1.0 | 2022-12-09 | Initial specifications | @sebastienlevert |
-
 
 ## Configuration file
 
@@ -17,17 +17,22 @@ This configuration can also be extended by "any" URLs to support 1P endpoints, v
 
 ```json
 {
-  "hostsToWatch": [
-    "graph.microsoft.com",
-    "graph.microsoft.us",
-    "dod-graph.microsoft.us",
-    "microsoftgraph.chinacloudapi.cn",
-    "*.sharepoint.*",
-    "*.sharepoint-df.*"
-    "customService.azurewebsites.net"
+  "urlsToWatch": [
+    "https://graph.microsoft.com/v1.0/*",
+    "https://graph.microsoft.com/beta/*",
+    "https://graph.microsoft.us/*",
+    "https://dod-graph.microsoft.us/*",
+    "https://microsoftgraph.chinacloudapi.cn/*",
+    "https://*.sharepoint.*/*_api/*",
+    "https://*.sharepoint.*/*_vti_bin/*",
+    "https://*.sharepoint-df.*/*_api/*",
+    "https://*.sharepoint-df.*/*_vti_bin/*",
+    "https://customService.azurewebsites.net/*"
   ]
 }
 ```
+
+We want to watch full URLs instead of just hosts, so that we can intercept only API calls. This will let users have more control over the URLs they want to watch. Additionally, it will make it possible to use the Proxy when building solutions connected to Microsoft Graph using SPFx, which require that users are able to navigate to web pages in the browser, which are hosted on the same domain as the API calls.
 
 ## Remove the `--cloud` option on the Proxy
 


### PR DESCRIPTION
This PR contains an updated proposal for supporting multiple URLs. I propose that we monitor full URLs rather than just the host names. Aside from giving users more control over the URLs they want to monitor, we'll let them use the Proxy when building solutions using SPFx, which require that users are able to navigate to web pages hosted on the same domain as the API calls.