### PR TITLE
ci: build and copy plugins project separately

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,7 +23,11 @@ jobs:
         with:
           dotnet-version: 6.0.x
       - name: Publish ${{ matrix.architecture }}
-        run: dotnet publish ./msgraph-developer-proxy/msgraph-developer-proxy.csproj -c Release -p:PublishSingleFile=true -r ${{ matrix.architecture }} -o ./${{ env.release }}
+        run: dotnet publish ./msgraph-developer-proxy/msgraph-developer-proxy.csproj -c Release -p:PublishSingleFile=true -r ${{ matrix.architecture }} --self-contained -o ./${{ env.release }}
+      - name: Build plugins
+        run: dotnet build ./msgraph-developer-proxy-plugins/msgraph-developer-proxy-plugins.csproj -c Release -r ${{ matrix.architecture }} --no-self-contained
+      - name: Add plugins to output
+        run: cp ./msgraph-developer-proxy/bin/Release/net6.0/${{ matrix.architecture }}/GraphProxyPlugins ./${{ env.release }}
       - name: Archive Release ${{ env.release }}
         uses: thedoctor0/zip-release@master
         with:

--- a/msgraph-developer-proxy-plugins/msgraph-developer-proxy-plugins.csproj
+++ b/msgraph-developer-proxy-plugins/msgraph-developer-proxy-plugins.csproj
@@ -35,7 +35,7 @@
         the build starts, which may miss files created during the build. -->
       <MySourceFiles Include="$(OutDir)\**\*.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(MySourceFiles)" DestinationFiles="$(SolutionDir)msgraph-developer-proxy\$(OutDir)\GraphProxyPlugins\%(RecursiveDir)%(Filename)%(Extension)" />
+    <Copy SourceFiles="@(MySourceFiles)" DestinationFiles="$(ProjectDir)..\msgraph-developer-proxy\$(OutDir)\GraphProxyPlugins\%(RecursiveDir)%(Filename)%(Extension)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
refactors plugins project to use ProjectDir token to allow the project to be build separately using cli tools.
add steps to the release pipeline to ensure that plugins are included in the release packages

Closes #134 