### PR TITLE
Adds generic chaos plugin

### DIFF
--- a/msgraph-developer-proxy-plugins/RandomErrors/GenericErrorResponse.cs
+++ b/msgraph-developer-proxy-plugins/RandomErrors/GenericErrorResponse.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Graph.DeveloperProxy.Plugins.RandomErrors;
+
+public class GenericErrorResponse {
+    [JsonPropertyName("statusCode")]
+    public int StatusCode { get; set; }
+    [JsonPropertyName("headers")]
+    public Dictionary<string, string>? Headers { get; set; }
+    [JsonPropertyName("body")]
+    public dynamic? Body { get; set; }
+    [JsonPropertyName("addDynamicRetryAfter")]
+    public bool? AddDynamicRetryAfter { get; set; } = false;
+}

--- a/msgraph-developer-proxy-plugins/RandomErrors/GenericErrorResponsesLoader.cs
+++ b/msgraph-developer-proxy-plugins/RandomErrors/GenericErrorResponsesLoader.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Graph.DeveloperProxy.Abstractions;
+using System.Text.Json;
+
+namespace Microsoft.Graph.DeveloperProxy.Plugins.RandomErrors;
+
+internal class GenericErrorResponsesLoader : IDisposable {
+    private readonly ILogger _logger;
+    private readonly GenericRandomErrorConfiguration _configuration;
+
+    public GenericErrorResponsesLoader(ILogger logger, GenericRandomErrorConfiguration configuration) {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+    }
+
+    private string _errorsFile => Path.Combine(Directory.GetCurrentDirectory(), _configuration.ErrorsFile ?? "");
+    private FileSystemWatcher? _watcher;
+
+    public void LoadResponses() {
+        if (!File.Exists(_errorsFile)) {
+            _logger.LogWarn($"File {_configuration.ErrorsFile} not found in the current directory. No error responses will be loaded");
+            _configuration.Responses = Array.Empty<GenericErrorResponse>();
+            return;
+        }
+
+        try {
+            var responsesString = File.ReadAllText(_errorsFile);
+            var responsesConfig = JsonSerializer.Deserialize<GenericRandomErrorConfiguration>(responsesString);
+            IEnumerable<GenericErrorResponse>? configResponses = responsesConfig?.Responses;
+            if (configResponses is not null) {
+                _configuration.Responses = configResponses;
+                _logger.LogInfo($"Error responses for {configResponses.Count()} url patterns loaded from from {_configuration.ErrorsFile}");
+            }
+        }
+        catch (Exception ex) {
+            _logger.LogError($"An error has occurred while reading {_configuration.ErrorsFile}:");
+            _logger.LogError(ex.Message);
+        }
+    }
+
+    public void InitResponsesWatcher() {
+        if (_watcher is not null) {
+            return;
+        }
+
+        string path = Path.GetDirectoryName(_errorsFile) ?? throw new InvalidOperationException($"{_errorsFile} is an invalid path");
+        _watcher = new FileSystemWatcher(path);
+        _watcher.NotifyFilter = NotifyFilters.CreationTime
+                             | NotifyFilters.FileName
+                             | NotifyFilters.LastWrite
+                             | NotifyFilters.Size;
+        _watcher.Filter = Path.GetFileName(_errorsFile);
+        _watcher.Changed += ResponsesFile_Changed;
+        _watcher.Created += ResponsesFile_Changed;
+        _watcher.Deleted += ResponsesFile_Changed;
+        _watcher.Renamed += ResponsesFile_Changed;
+        _watcher.EnableRaisingEvents = true;
+
+        LoadResponses();
+    }
+
+    private void ResponsesFile_Changed(object sender, FileSystemEventArgs e) {
+        LoadResponses();
+    }
+
+    public void Dispose() {
+        _watcher?.Dispose();
+    }
+}

--- a/msgraph-developer-proxy-plugins/RandomErrors/GenericRandomErrorPlugin.cs
+++ b/msgraph-developer-proxy-plugins/RandomErrors/GenericRandomErrorPlugin.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Graph.DeveloperProxy.Abstractions;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Titanium.Web.Proxy.EventArguments;
+using Titanium.Web.Proxy.Http;
+using Titanium.Web.Proxy.Models;
+
+namespace Microsoft.Graph.DeveloperProxy.Plugins.RandomErrors;
+internal enum GenericRandomErrorFailMode {
+    Throttled,
+    Random,
+    PassThru
+}
+
+public class GenericRandomErrorConfiguration {
+    public int Rate { get; set; } = 0;
+    public string? ErrorsFile { get; set; }
+    [JsonPropertyName("responses")]
+    public IEnumerable<GenericErrorResponse> Responses { get; set; } = Array.Empty<GenericErrorResponse>();
+}
+
+public class GenericRandomErrorPlugin : BaseProxyPlugin {
+    private readonly GenericRandomErrorConfiguration _configuration = new();
+    private GenericErrorResponsesLoader? _loader = null;
+
+    public override string Name => nameof(GenericRandomErrorPlugin);
+
+    private const int retryAfterInSeconds = 5;
+    private readonly Dictionary<string, DateTime> _throttledRequests;
+    private readonly Random _random;
+
+    public GenericRandomErrorPlugin() {
+        _random = new Random();
+        _throttledRequests = new Dictionary<string, DateTime>();
+    }
+
+    // uses config to determine if a request should be failed
+    private GenericRandomErrorFailMode ShouldFail(ProxyRequestArgs e) {
+        var r = e.Session.HttpClient.Request;
+        string key = BuildThrottleKey(r);
+        if (_throttledRequests.TryGetValue(key, out DateTime retryAfterDate)) {
+            if (retryAfterDate > DateTime.Now) {
+                _logger?.LogRequest(new[] { $"Calling {r.Url} again before waiting for the Retry-After period.", "Request will be throttled" }, MessageType.Failed, new LoggingContext(e.Session));
+                // update the retryAfterDate to extend the throttling window to ensure that brute forcing won't succeed.
+                _throttledRequests[key] = retryAfterDate.AddSeconds(retryAfterInSeconds);
+                return GenericRandomErrorFailMode.Throttled;
+            }
+            else {
+                // clean up expired throttled request and ensure that this request is passed through.
+                _throttledRequests.Remove(key);
+                return GenericRandomErrorFailMode.PassThru;
+            }
+        }
+        return _random.Next(1, 100) <= _configuration.Rate ? GenericRandomErrorFailMode.Random : GenericRandomErrorFailMode.PassThru;
+    }
+
+    private void FailResponse(ProxyRequestArgs e, GenericRandomErrorFailMode failMode) {
+        GenericErrorResponse error;
+        if (failMode == GenericRandomErrorFailMode.Throttled) {
+            error = new GenericErrorResponse {
+                StatusCode = (int)HttpStatusCode.TooManyRequests,
+                Headers = new Dictionary<string, string> {
+                    { "Retry-After", retryAfterInSeconds.ToString() }
+                }
+            };
+        }
+        else {
+            // pick a random error response for the current request
+            error = _configuration.Responses.ElementAt(_random.Next(0, _configuration.Responses.Count()));
+        }
+        UpdateProxyResponse(e, error);
+    }
+
+    private void UpdateProxyResponse(ProxyRequestArgs ev, GenericErrorResponse error) {
+        SessionEventArgs session = ev.Session;
+        Request request = session.HttpClient.Request;
+        var headers = error.Headers is not null ? 
+            error.Headers.Select(h => new HttpHeader(h.Key, h.Value)).ToList() :
+            new List<HttpHeader>();
+        if (error.StatusCode == (int)HttpStatusCode.TooManyRequests &&
+            error.AddDynamicRetryAfter.GetValueOrDefault(false)) {
+            var retryAfterDate = DateTime.Now.AddSeconds(retryAfterInSeconds);
+            _throttledRequests[BuildThrottleKey(request)] = retryAfterDate;
+            headers.Add(new HttpHeader("Retry-After", retryAfterInSeconds.ToString()));
+        }
+
+        string body = error.Body is null ? string.Empty : JsonSerializer.Serialize(error.Body);
+        _logger?.LogRequest(new[] { $"{error.StatusCode} {((HttpStatusCode)error.StatusCode).ToString()}" }, MessageType.Chaos, new LoggingContext(ev.Session));
+        session.GenericResponse(body ?? string.Empty, (HttpStatusCode)error.StatusCode, headers);
+    }
+
+    private string BuildThrottleKey(Request r) => $"{r.Method}-{r.Url}";
+
+    public override void Register(IPluginEvents pluginEvents,
+                         IProxyContext context,
+                         ISet<Regex> urlsToWatch,
+                         IConfigurationSection? configSection = null) {
+        base.Register(pluginEvents, context, urlsToWatch, configSection);
+
+        configSection?.Bind(_configuration);
+        _loader = new GenericErrorResponsesLoader(_logger!, _configuration);
+
+        pluginEvents.Init += OnInit;
+        pluginEvents.BeforeRequest += OnRequest;
+    }
+
+    private void OnInit(object? sender, InitArgs e) {
+        _loader?.InitResponsesWatcher();
+    }
+
+    private void OnRequest(object? sender, ProxyRequestArgs e) {
+        var session = e.Session;
+        var state = e.ResponseState;
+        if (!e.ResponseState.HasBeenSet
+            && _urlsToWatch is not null
+            && e.ShouldExecute(_urlsToWatch)) {
+            var failMode = ShouldFail(e);
+
+            if (failMode == GenericRandomErrorFailMode.PassThru && _configuration.Rate != 100) {
+                _logger?.LogRequest(new[] { "Passed through" }, MessageType.PassedThrough, new LoggingContext(e.Session));
+                return;
+            }
+            FailResponse(e, failMode);
+            state.HasBeenSet = true;
+        }
+    }
+}

--- a/msgraph-developer-proxy/appsettings.json
+++ b/msgraph-developer-proxy/appsettings.json
@@ -48,10 +48,10 @@
       "configSection": "mocksPlugin"
     },
     {
-      "name": "RandomErrorPlugin",
+      "name": "GraphRandomErrorPlugin",
       "disabled": false,
       "pluginPath": "GraphProxyPlugins\\msgraph-developer-proxy-plugins.dll",
-      "configSection": "randomErrorsPlugin"
+      "configSection": "graphRandomErrorsPlugin"
     },
     {
       "name": "ODataPagingGuidancePlugin",
@@ -75,9 +75,9 @@
     "https://*.sharepoint-df.*/*_vti_bin/*"
   ],
   "mocksPlugin": {
-    "mocksFile":  "responses.json"
+    "mocksFile": "responses.json"
   },
-  "randomErrorsPlugin": {
+  "graphRandomErrorsPlugin": {
     "rate": 50,
     "allowedErrors": [ 429, 500, 502, 503, 504, 507 ]
   },


### PR DESCRIPTION
Adds generic chaos plugin that can be used to simulate errors with any API.
Renames the existing random error plugin to `GraphRandomErrorPlugin` to disambiguate between the one with specific Graph behaviors and the generic one.