### PR TITLE
Specs for the metered APIs

### DIFF
--- a/specs/metered-guidance-errors.md
+++ b/specs/metered-guidance-errors.md
@@ -58,9 +58,9 @@ In the `BeforeRequest` event, the plugin will check if the request URL is part o
 - The 'More info' is coming from the `billingInformation` property.
 
 ```shell
-[ REQUEST ]    GET hhttps://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages
+[ REQUEST ]    GET hhttps://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages?model=randomModel
 [   API   ]  ┌ Passed through
-             └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages
+             └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages?model=randomModel
 [ WARNING ]  ┌ You are using a metered API with an invalid a payment model parameter (`randomModel`).
              │ More info at https://learn.microsoft.com/en-us/graph/teams-licenses#payment-models
              └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages
@@ -70,7 +70,8 @@ In the `BeforeRequest` event, the plugin will check if the request URL is part o
 
 - When registered, the plugin randomly generates 3 new HTTP 402 errors.
 - The `--failure-rate` should be the same that the one provided on the `GraphRandomErrorPlugin`.
-- 402s are dependent on the HTTP Verb that is used. In the configuration file, HTTP Verbs need to be explicit.\* 402s should only be returned for the metered endpoints and only for the HTTP Verb used.
+- 402s are dependent on the HTTP Verb that is used. In the configuration file, HTTP Verbs need to be explicit.
+- 402s should only be returned for the metered endpoints and only for the HTTP Verb used.
 - The list of 402s is available [here](https://learn.microsoft.com/en-us/graph/teams-licenses#payment-related-errors):
 
 | Error code             | Scenario                                         | HTTP Verb    | Sample error message                                                                                      |
@@ -96,7 +97,8 @@ The plugin will have its own preset file. This configuration file is where meter
 
 - Each `urlToWatch` are rolled up to a single metered API. Multiple `urlToWatch` value means each endpoint behaves the same and should be treated as a metered API.
 - `supportedPaymentModels` are query string passed to the endpoint. If not present, they are considered in Evaluation Mode. If present, they need to be available in the `supportedPaymentModels` list.
-- `billingInformation` represents an URL to get more billing information on the API (if any).
+- `registrationForm` represents an URL to request access to the API (if any).
+- `httpVerbs` represents an array of HTTP Verbs that are effectively metered. If none are provided, we assume GET.
 - `registrationForm` represents an URL to request access to the API (if any).
 
 ```json
@@ -143,7 +145,6 @@ The plugin will have its own preset file. This configuration file is where meter
         "https://graph.microsoft.com/beta/*/assignSensitivityLabel"
       ],
       "httpVerbs": ["POST"],
-      "billingInformation": "",
       "registrationForm": "https://aka.ms/PreviewSPOPremiumAPI"
     }
   ]

--- a/specs/metered-guidance-errors.md
+++ b/specs/metered-guidance-errors.md
@@ -1,0 +1,111 @@
+# Metered APIs guidance and random errors
+
+Using Metered plugin, developers can ensure are aware and utilize the Metered APIs in the most efficient way possible.
+
+Metered APIs allows you to get access to advanced capabilities in Microsoft Graph. They require an active Azure subscription with the calling application. Some of these metered APIs are protected and require additional validation beyond permissions and admin consent. The main goal of this guidance is to know that the APIs they are calling would require extra action when deployed in production and could incur a cost.
+
+## History
+
+| Version | Date | Comments | Author |
+| ------- | ---- | -------- | ------ |
+| 1.0 | 2023-03-20 | Initial specifications | @sebastienlevert |
+
+## Configuration
+
+N/A
+
+## Implementation
+
+> **Note**
+> This metered APIs plugin is only valid for Microsoft Graph requests.  
+
+### Guidance
+Metered APIs guidance will be implemented as a plugin, subscribed to one events: `BeforeRequest`.
+
+In the `BeforeRequest` event, the plugin will check if the request URL is part of the identified metered APIs. This list of APIs is documented in the official Microsoft Graph Docs [here](https://learn.microsoft.com/en-us/graph/metered-api-list?view=graph-rest-1.0). This list will likely grow but as a first step, we will be using a static configuration file to identify the endpoints to mark as metered. If the request is targeted at a metered API, we will emit a log message that will include text telling the developer the endpoint is metered and will include a link to the Metered APIs and services in Microsoft Graph documentation: `https://learn.microsoft.com/en-us/graph/metered-api-list`.
+
+```shell
+[ REQUEST ]    GET hhttps://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages
+[   API   ]  ┌ Passed through
+             └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages
+[ WARNING ]  ┌ This is a metered API.
+             │ More info at https://learn.microsoft.com/en-us/graph/teams-licenses
+             └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages 
+```
+
+### Random Errors
+When registered, the plugin should register 3 new errors for the `GraphRandomErrorPlugin` (The list is coming from https://learn.microsoft.com/en-us/graph/teams-licenses#payment-related-errors):
+
+| Error code | Scenario | Sample error message |
+|:-----------|:-----------|:-----------------|
+| 402 (Payment Required) | Passing `model=A` without a Microsoft E5 license |`...needs a valid license to access this API...`, `...tenant needs a valid license to access this API...`|
+| 402 (Payment Required) | Calling Patch API passing `model=B` |`...query parameter 'model' does not support value 'B' for this API. Use billing model 'A'...`|
+| 402 (Payment Required) | `Evaluation mode` capacity exceeded |`...evaluation mode capacity has been exceeded. Use a valid billing model...`|
+
+## Configuration file
+
+The plugin will have its own section in the `appSettings.json` configuration file where metered APIs will be listed. This file should have default values for all supported Microsoft Graph clouds.
+
+```json
+{
+  "name": "GraphMeteredGuidancePlugin",
+  "enabled": true,
+  "pluginPath": "GraphProxyPlugins\\msgraph-developer-proxy-plugins.dll",      
+  "meteredApis": [
+    {
+      "urlsToWatch": [
+        "https://graph.microsoft.com/v1.0/users/*/chats/getAllMessages",
+        "https://graph.microsoft.com/beta/users/*/chats/getAllMessages",
+      ],
+      "supportedPaymentModels": [
+        "model=A",
+        "model=B"
+      ],
+      "documentationUrl": "",
+      "billingInformation": "https://learn.microsoft.com/en-us/graph/teams-licenses",
+      "registrationForm": "https://aka.ms/teamsgraph/requestaccess"
+    },
+    {
+      "urlsToWatch": [
+        "https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages",
+        "https://graph.microsoft.com/beta/teams/*/channels/getAllMessages",
+      ],
+      "supportedPaymentModels": [
+        "model=A",
+        "model=B"
+      ],
+      "billingInformation": "https://learn.microsoft.com/en-us/graph/teams-licenses",
+      "registrationForm": "https://aka.ms/teamsgraph/requestaccess"
+    },
+    {
+      "urlsToWatch": [
+        "https://graph.microsoft.com/v1.0/teams/*/channels/*/messages/*",
+        "https://graph.microsoft.com/beta/teams/*/channels/*/messages/*",
+        "https://graph.microsoft.com/v1.0/teams/*/channels/*/messages/*/replies/*",
+        "https://graph.microsoft.com/beta/teams/*/channels/*/messages/*/replies/*",
+        "https://graph.microsoft.com/v1.0/chats/*/messages/{message-id}*",
+        "https://graph.microsoft.com/beta/chats/*/messages/{message-id}*",
+      ],
+      "httpVerbs": [
+        "PATCH"
+      ],
+      "supportedPaymentModels": [
+        "model=A"
+      ],
+      "billingInformation": "https://learn.microsoft.com/en-us/graph/teams-licenses",
+      "registrationForm": "https://aka.ms/teamsgraph/requestaccess"
+    },
+    {
+      "urlsToWatch": [
+        "https://graph.microsoft.com/v1.0/*/assignSensitivityLabel",
+        "https://graph.microsoft.com/beta/*/assignSensitivityLabel",
+      ],
+      "httpVerbs": [
+        "POST"
+      ],
+      "billingInformation": "",
+      "registrationForm": "https://aka.ms/PreviewSPOPremiumAPI"
+    }
+  ]
+}
+```

--- a/specs/metered-guidance-errors.md
+++ b/specs/metered-guidance-errors.md
@@ -1,14 +1,14 @@
 # Metered APIs guidance and random errors
 
-Using Metered plugin, developers can ensure are aware and utilize the Metered APIs in the most efficient way possible.
+Using the Metered Microsoft Graph APIs plugin, customers can understand if they use metered APIs in Microsoft Graph and can test how their application will response to 402 Payment Required responses.
 
 Metered APIs allows you to get access to advanced capabilities in Microsoft Graph. They require an active Azure subscription with the calling application. Some of these metered APIs are protected and require additional validation beyond permissions and admin consent. The main goal of this guidance is to know that the APIs they are calling would require extra action when deployed in production and could incur a cost.
 
 ## History
 
-| Version | Date | Comments | Author |
-| ------- | ---- | -------- | ------ |
-| 1.0 | 2023-03-20 | Initial specifications | @sebastienlevert |
+| Version | Date       | Comments               | Author           |
+| ------- | ---------- | ---------------------- | ---------------- |
+| 1.0     | 2023-03-20 | Initial specifications | @sebastienlevert |
 
 ## Configuration
 
@@ -17,92 +17,132 @@ N/A
 ## Implementation
 
 > **Note**
-> This metered APIs plugin is only valid for Microsoft Graph requests.  
+> This metered APIs plugin is only valid for Microsoft Graph requests.
 
 ### Guidance
+
 Metered APIs guidance will be implemented as a plugin, subscribed to one events: `BeforeRequest`.
 
 In the `BeforeRequest` event, the plugin will check if the request URL is part of the identified metered APIs. This list of APIs is documented in the official Microsoft Graph Docs [here](https://learn.microsoft.com/en-us/graph/metered-api-list?view=graph-rest-1.0). This list will likely grow but as a first step, we will be using a static configuration file to identify the endpoints to mark as metered. If the request is targeted at a metered API, we will emit a log message that will include text telling the developer the endpoint is metered and will include a link to the Metered APIs and services in Microsoft Graph documentation: `https://learn.microsoft.com/en-us/graph/metered-api-list`.
+
+#### Passthrough
+
+- The 'More info' is coming from the `billingInformation` property.
+- The 'Request access' is coming from the `registrationForm` property.
+
+```shell
+[ REQUEST ]    GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages?model=A
+[   API   ]  ┌ Passed through
+             └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages?model=A
+[   INFO  ]  ┌ This is a metered API.
+             │ More info at https://learn.microsoft.com/en-us/graph/teams-licenses
+             │ Request access at https://aka.ms/teamsgraph/requestaccess
+             └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages?model=A
+```
+
+#### Using the API without a payment model
+
+- The 'More info' is coming from the `billingInformation` property.
 
 ```shell
 [ REQUEST ]    GET hhttps://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages
 [   API   ]  ┌ Passed through
              └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages
-[ WARNING ]  ┌ This is a metered API.
-             │ More info at https://learn.microsoft.com/en-us/graph/teams-licenses
-             └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages 
+[ WARNING ]  ┌ You are using a metered API without a payment model parameter. You are currently in Evaluation Mode and the API will eventually stop returning data
+             │ More info at https://learn.microsoft.com/en-us/graph/teams-licenses#evaluation-mode-default-requirements
+             └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages
+```
+
+#### Using the API with an invalid payment model
+
+- The 'More info' is coming from the `billingInformation` property.
+
+```shell
+[ REQUEST ]    GET hhttps://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages
+[   API   ]  ┌ Passed through
+             └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages
+[ WARNING ]  ┌ You are using a metered API with an invalid a payment model parameter (`randomModel`).
+             │ More info at https://learn.microsoft.com/en-us/graph/teams-licenses#payment-models
+             └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages
 ```
 
 ### Random Errors
-When registered, the plugin should register 3 new errors for the `GraphRandomErrorPlugin` (The list is coming from https://learn.microsoft.com/en-us/graph/teams-licenses#payment-related-errors):
 
-| Error code | Scenario | Sample error message |
-|:-----------|:-----------|:-----------------|
-| 402 (Payment Required) | Passing `model=A` without a Microsoft E5 license |`...needs a valid license to access this API...`, `...tenant needs a valid license to access this API...`|
-| 402 (Payment Required) | Calling Patch API passing `model=B` |`...query parameter 'model' does not support value 'B' for this API. Use billing model 'A'...`|
-| 402 (Payment Required) | `Evaluation mode` capacity exceeded |`...evaluation mode capacity has been exceeded. Use a valid billing model...`|
+- When registered, the plugin randomly generates 3 new HTTP 402 errors.
+- The `--failure-rate` should be the same that the one provided on the `GraphRandomErrorPlugin`.
+- 402s are dependent on the HTTP Verb that is used. In the configuration file, HTTP Verbs need to be explicit.\* 402s should only be returned for the metered endpoints and only for the HTTP Verb used.
+- The list of 402s is available [here](https://learn.microsoft.com/en-us/graph/teams-licenses#payment-related-errors):
+
+| Error code             | Scenario                                         | HTTP Verb    | Sample error message                                                                                      |
+| :--------------------- | :----------------------------------------------- | :----------- | :-------------------------------------------------------------------------------------------------------- |
+| 402 (Payment Required) | Passing `model=A` without a Microsoft E5 license | GET          | `...needs a valid license to access this API...`, `...tenant needs a valid license to access this API...` |
+| 402 (Payment Required) | Calling Patch API passing `model=B`              | PATCH        | `...query parameter 'model' does not support value 'B' for this API. Use billing model 'A'...`            |
+| 402 (Payment Required) | `Evaluation mode` capacity exceeded              | GET or PATCH | `...evaluation mode capacity has been exceeded. Use a valid billing model...`                             |
+
+> **Note**
+> Full error messages are currently not available and we don't have specific information on the ODSP HTTP Errors yet. When we will get them, we will update the plugin to include them.
+
+#### Payment Required
+
+```shell
+[ REQUEST ]    GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages?model=A
+[  CHAOS  ]  ┌ 402 PaymentRequired (Needs a valid license to access this API)
+             └ GET https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages?model=A
+```
 
 ## Configuration file
 
-The plugin will have its own section in the `appSettings.json` configuration file where metered APIs will be listed. This file should have default values for all supported Microsoft Graph clouds.
+The plugin will have its own preset file. This configuration file is where metered APIs will be listed. This file should have default values for all supported Microsoft Graph clouds. As of today, only the commercial cloud supports Metered APIs.
+
+- Each `urlToWatch` are rolled up to a single metered API. Multiple `urlToWatch` value means each endpoint behaves the same and should be treated as a metered API.
+- `supportedPaymentModels` are query string passed to the endpoint. If not present, they are considered in Evaluation Mode. If present, they need to be available in the `supportedPaymentModels` list.
+- `billingInformation` represents an URL to get more billing information on the API (if any).
+- `registrationForm` represents an URL to request access to the API (if any).
 
 ```json
 {
-  "name": "GraphMeteredGuidancePlugin",
-  "enabled": true,
-  "pluginPath": "GraphProxyPlugins\\msgraph-developer-proxy-plugins.dll",      
-  "meteredApis": [
+  "plugins": [
+    {
+      "name": "GraphMeteredGuidancePlugin",
+      "enabled": true,
+      "pluginPath": "GraphProxyPlugins\\msgraph-developer-proxy-plugins.dll",
+      "configSection": "graphMeteredGuidancePlugin"
+    }
+  ],
+  "graphMeteredGuidancePlugin": [
     {
       "urlsToWatch": [
-        "https://graph.microsoft.com/v1.0/users/*/chats/getAllMessages",
-        "https://graph.microsoft.com/beta/users/*/chats/getAllMessages",
+        "https://graph.microsoft.com/*/users/*/chats/getAllMessages"
       ],
-      "supportedPaymentModels": [
-        "model=A",
-        "model=B"
-      ],
-      "documentationUrl": "",
+      "supportedPaymentModels": ["model=A", "model=B"],
       "billingInformation": "https://learn.microsoft.com/en-us/graph/teams-licenses",
       "registrationForm": "https://aka.ms/teamsgraph/requestaccess"
     },
     {
       "urlsToWatch": [
-        "https://graph.microsoft.com/v1.0/teams/*/channels/getAllMessages",
-        "https://graph.microsoft.com/beta/teams/*/channels/getAllMessages",
+        "https://graph.microsoft.com/*/teams/*/channels/getAllMessages"
       ],
-      "supportedPaymentModels": [
-        "model=A",
-        "model=B"
-      ],
+      "supportedPaymentModels": ["model=A", "model=B"],
       "billingInformation": "https://learn.microsoft.com/en-us/graph/teams-licenses",
       "registrationForm": "https://aka.ms/teamsgraph/requestaccess"
     },
     {
       "urlsToWatch": [
-        "https://graph.microsoft.com/v1.0/teams/*/channels/*/messages/*",
-        "https://graph.microsoft.com/beta/teams/*/channels/*/messages/*",
-        "https://graph.microsoft.com/v1.0/teams/*/channels/*/messages/*/replies/*",
-        "https://graph.microsoft.com/beta/teams/*/channels/*/messages/*/replies/*",
-        "https://graph.microsoft.com/v1.0/chats/*/messages/{message-id}*",
-        "https://graph.microsoft.com/beta/chats/*/messages/{message-id}*",
+        "https://graph.microsoft.com/*/teams/*/channels/*/messages/*",
+        "https://graph.microsoft.com/*/teams/*/channels/*/messages/*/replies/*",
+        "https://graph.microsoft.com/*/chats/*/messages/{message-id}*"
       ],
-      "httpVerbs": [
-        "PATCH"
-      ],
-      "supportedPaymentModels": [
-        "model=A"
-      ],
+      "httpVerbs": ["PATCH"],
+      "supportedPaymentModels": ["model=A"],
       "billingInformation": "https://learn.microsoft.com/en-us/graph/teams-licenses",
       "registrationForm": "https://aka.ms/teamsgraph/requestaccess"
     },
     {
       "urlsToWatch": [
         "https://graph.microsoft.com/v1.0/*/assignSensitivityLabel",
-        "https://graph.microsoft.com/beta/*/assignSensitivityLabel",
+        "https://graph.microsoft.com/beta/*/assignSensitivityLabel"
       ],
-      "httpVerbs": [
-        "POST"
-      ],
+      "httpVerbs": ["POST"],
       "billingInformation": "",
       "registrationForm": "https://aka.ms/PreviewSPOPremiumAPI"
     }


### PR DESCRIPTION
Adds the metered APIs specs. Closes #214.

A couple of questions I have : 

* Is it possible to register random error only when this plugin is enabled (402s)
* Can we watch on certain HTTP verbs (PATCH)