### PR TITLE
Moves product version to code

### DIFF
--- a/msgraph-developer-proxy/ProxyEngine.cs
+++ b/msgraph-developer-proxy/ProxyEngine.cs
@@ -28,13 +28,10 @@ public class ProxyEngine {
     private static string _productVersion = string.Empty;
     public static string ProductVersion {
         get {
-            if (_productVersion == string.Empty) {
-                var assemblyPath = Process.GetCurrentProcess()?.MainModule?.FileName ?? typeof(ProxyEngine).Assembly.Location;
-                var fileVersionInfo = FileVersionInfo.GetVersionInfo(assemblyPath);
-                _productVersion = fileVersionInfo?.ProductVersion!;
-            }
-
-            return _productVersion;
+            // product version to display in the terminal and used for
+            // new version notification. Added here because .net doesn't
+            // stamp version on assemblies on non-Windows OSes
+            return "0.7.0";
         }
     }
 

--- a/msgraph-developer-proxy/UpdateNotification.cs
+++ b/msgraph-developer-proxy/UpdateNotification.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics;
 using System.Net.Http.Headers;
-using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 


### PR DESCRIPTION
Moves product version to code, to reliably detect new versions. Because .net doesn't stamp version numbers on assemblies on non-Windows OSes, we end up with the current version being 0.0.0.0.